### PR TITLE
Settings: make AudioFX tile not translatable

### DIFF
--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -953,7 +953,7 @@
     <string name="qs_tile_compass">Compass</string>
     <string name="qs_tile_lockscreen">Lockscreen</string>
     <string name="qs_tile_lte">LTE</string>
-    <string name="qs_tile_visualizer">AudioFX</string>
+    <string name="qs_tile_visualizer" translatable="false">AudioFX</string>
     <string name="qs_tile_screen_timeout">Screen timeout</string>
 
     <string name="qs_main_tiles_title">Enlarge first row</string>


### PR DESCRIPTION
Change-Id: Ia8b9356ea3ccee8a8beb821f7ae66fb9fa283498
Signed-off-by: Roman Birg roman@cyngn.com
